### PR TITLE
fix bug: Throw an exception if a segment not found

### DIFF
--- a/Utils/HlsSreamer.php
+++ b/Utils/HlsSreamer.php
@@ -78,6 +78,7 @@ class HlsSreamer
 
                 $segment = new Segment($line[0], $line[1], $line[2], $line[3], $line[4],$path);
                 if ($segment->getStartTime() <= $time && $segment->getEndTime() >= $time) {
+                    fclose($file_handle);
                     return $segment;
                 }
             }
@@ -86,6 +87,7 @@ class HlsSreamer
         }catch (\Exception $e){
             throw new ArchiveNotFoundException("Archive for timestamp $time not found");
         }
+        throw new ArchiveNotFoundException("Archive for timestamp $time not found");
     }
 
 


### PR DESCRIPTION
**Error Description:** PHP Fatal error:  Uncaught Error: Call to a member function getEndTime() on null in /tvip-jsonapi/Utils/HlsSreamer.php:65\nStack trace:\n#0 /tvip-jsonapi/Controller/DVRController.php(38): Utils\\HlsSreamer->getSegmentsByTime('1555914592')\n#1 [internal function]: Controller\\DVRController->timeShiftAction('120', '1555914592')\n#2 /tvip-jsonapi/Controller/Router.php(277): call_user_func_array(Array, Array)\n#3 /tvip-jsonapi/Controller/Router.php(113): Controller\\Router->executeHandler('Controller\\\\DVRC...', Array)\n#4 /tvip-jsonapi/tvipapi/index.php(157): Controller\\Router->getResponse()\n#5 {main}\n  thrown in /tvip-jsonapi/Utils/HlsSreamer.php on line 65
**How to reproduce:** twice push on the PLAY/PAUSE button in live 
**Solution:** throw an exception if a segment not found